### PR TITLE
Use Thonny to open examples instead of IDLE

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -63,7 +63,7 @@ Description: Documentation for the Raspberry Pi Sense HAT emulator.
 Package: sense-emu-tools
 Architecture: all
 Section: devel
-Depends: ${misc:Depends}, ${python3:Depends}, python3-sense-emu (>= ${binary:Version}), python3-gi, python3-gi-cairo, idle3
+Depends: ${misc:Depends}, ${python3:Depends}, python3-sense-emu (>= ${binary:Version}), python3-gi, python3-gi-cairo, python3-thonny
 Description: Emulator for the Raspberry Pi Sense HAT.
  sense-emu is an emulator of the Raspberry Pi Sense HAT which runs on multiple
  platforms, and provides an emulation of each sensor on the HAT, along with the

--- a/sense_emu/gui.py
+++ b/sense_emu/gui.py
@@ -266,10 +266,7 @@ class EmuApplication(Gtk.Application):
         # right but it's also cross-platform and cross-version compatible
         # (works on Py 2.x on Windows and UNIX, and Py 3.x on Windows and UNIX;
         # almost any other variant fails for some combination)
-        subprocess.Popen([
-            sys.executable,
-            '-c', 'from idlelib.PyShell import main; main()',
-            filename])
+        subprocess.Popen(["thonny", filename])
 
     def on_play(self, action, param):
         open_dialog = Gtk.FileChooserDialog(


### PR DESCRIPTION
We're not installing IDLE by default in Buster; so it would be better if these examples could be opened in Thonny (which is installed by default) instead. The attached patch seems to work on Pi - don't know if it will do so on other platforms, given the comment above the change!