### PR TITLE
in python ver >= 3.6 is PyShell renamed to pyshell

### DIFF
--- a/sense_emu/gui.py
+++ b/sense_emu/gui.py
@@ -266,10 +266,10 @@ class EmuApplication(Gtk.Application):
         # right but it's also cross-platform and cross-version compatible
         # (works on Py 2.x on Windows and UNIX, and Py 3.x on Windows and UNIX;
         # almost any other variant fails for some combination)
-        subprocess.Popen([
-            sys.executable,
-            '-c', 'from idlelib.PyShell import main; main()',
-            filename])
+        command='from idlelib.PyShell import main; main()'
+        if sys.hexversion >= 0x030600f0:
+            command='from idlelib.pyshell import main; main()'
+        subprocess.Popen([sys.executable, '-c', command, filename])
 
     def on_play(self, action, param):
         open_dialog = Gtk.FileChooserDialog(


### PR DESCRIPTION
see
https://bugs.python.org/issue24225

Signed-off-by: Jan Hrubes <h.hrubes@gmail.com>